### PR TITLE
Refactor key naming and add TPM class

### DIFF
--- a/issuer.py
+++ b/issuer.py
@@ -1,12 +1,11 @@
-from ecdsa import SigningKey, VerifyingKey, SECP256k1
+from ecdsa import SigningKey, SECP256k1
 
 
 class Issuer:
     def __init__(self):
-        self.signing_key = SigningKey.generate(curve=SECP256k1)  # Generate a new ECDSA key pair
-        self.verifying_key = self.signing_key.get_verifying_key()
+        self.ek = SigningKey.generate(curve=SECP256k1)  # Generate a new ECDSA key pair
+        self.aik = self.ek.get_verifying_key()
 
     def issue(self):
         # Issue a private key to a host (in reality this should preferably be done securely)
-        host_signing_key = SigningKey.generate(curve=SECP256k1)
-        return host_signing_key, host_signing_key.get_verifying_key()
+        return self.ek, self.aik

--- a/main.py
+++ b/main.py
@@ -1,22 +1,23 @@
+from host import Host
+from issuer import Issuer
+from tpm import TPM
+from verifier import Verifier
+
 if __name__ == '__main__':
-    from issuer import Issuer
-    from host import Host
-    from verifier import Verifier
 
     # Create an issuer
     issuer = Issuer()
 
     # The issuer issues a new private key to a host
-    host = Host(issuer)
+    tpm = TPM(issuer)
 
     # The host creates an attestation
     message = b"Hello, World!"  # The message to be signed
-    signature = host.attest(message)
+    signature = tpm.attest(message)
 
     # A verifier verifies the attestation
-    verifier = Verifier(issuer.verifying_key)
+    verifier = Verifier(issuer.aik)
 
     # Verify the signature
-    is_valid = host.verifying_key.verify(signature, message)
-
+    is_valid = verifier.verify(signature, message, issuer.aik)
     print(f"Signature valid: {is_valid}")

--- a/tpm.py
+++ b/tpm.py
@@ -1,4 +1,7 @@
-class Host:
+from ecdsa import SigningKey, SECP256k1
+
+
+class TPM:
     def __init__(self, issuer):
         self.ek, self.aik = issuer.issue()
 

--- a/verifier.py
+++ b/verifier.py
@@ -1,7 +1,7 @@
 class Verifier:
-    def __init__(self, issuer_verifying_key):
-        self.issuer_verifying_key = issuer_verifying_key
+    def __init__(self, issuer_aik):
+        self.issuer_verifying_aik = issuer_aik
 
-    def verify(self, signature, message, host_verifying_key):
+    def verify(self, signature, message, tpm_aik):
         # Verify an attestation
-        return host_verifying_key.verify(signature, message) and self.issuer_verifying_key.verify(signature, message)
+        return tpm_aik.verify(signature, message) and self.issuer_verifying_aik.verify(signature, message)


### PR DESCRIPTION
Renamed keys in `Issuer`, `Host`, and `Verifier` for clarity, changing 'signing_key', 'verifying_key' to 'ek' and 'aik'. Removed direct generation of host's signing key, now all keys are directly issued by `Issuer`. Also introduced a new `TPM` class mimicking `Host` class behavior, demonstrating flexible attestation source.